### PR TITLE
fix: bump action/checkout version

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "📥 Check-out"
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: "✏️ Generate release changelog"
         uses: heinrichreimer/github-changelog-generator-action@v2.1.1
         with:


### PR DESCRIPTION
It appears that most of the problems we have been running into with the
changelog actions are a direct result of a bug in the checkout action.

See: <https://stackoverflow.com/questions/57921401/push-to-origin-from-github-action/58393457#58393457>
Fixes #16