### PR TITLE
fix: allow hash-style headers in markdown files

### DIFF
--- a/.mdl_style.rb
+++ b/.mdl_style.rb
@@ -1,2 +1,1 @@
-rule 'MD003', :style => :setext_with_atx
 rule 'MD029', :style => :ordered


### PR DESCRIPTION
Removing the configuration rule for markdown lint which forced a
specific style.  This moves back to requiring headers to be a consistent
style instead of requiring a specific style.

Fixes #37